### PR TITLE
[FEATURE] Bookmark should be opened on same page

### DIFF
--- a/src/components/widgets/BookmarkWidget/BookmarkWidget.tsx
+++ b/src/components/widgets/BookmarkWidget/BookmarkWidget.tsx
@@ -7,7 +7,7 @@ type BookmarkWidgetProps = WidgetData;
 
 const BookmarkWidget = ({ name, link }: BookmarkWidgetProps) => {
 	const onClickHandler = (e: SyntheticEvent<HTMLButtonElement>) => {
-		window.open(link, "_blank");
+		window.open(link, "_self");
 		e.currentTarget.blur();
 	};
 


### PR DESCRIPTION
Fixed bug so bookmark links now open in current tab instead of a new one. Addresses issue #5 