### PR TITLE
[FIX] Fix footer on mobile devices

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -18,15 +18,17 @@ const Footer = () => {
 				>
 					contributors
 				</a>
-				<span> | </span>
-				<a
-					target="_blank"
-					className={styles.github}
-					href="https://github.com/yashchaudhari008/minime"
-				>
-					<FontAwesomeIcon className={styles.icon} icon={faGithub} />
-					Github Page
-				</a>
+				<span> |</span>
+				<span className={styles.githubContainer}>
+					<a
+						target="_blank"
+						className={styles.github}
+						href="https://github.com/yashchaudhari008/minime"
+					>
+						<FontAwesomeIcon className={styles.icon} icon={faGithub} />
+						Github Page
+					</a>
+				</span>
 			</p>
 		</footer>
 	);

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -6,7 +6,7 @@ import styles from "./footer.module.scss";
 const Footer = () => {
 	return (
 		<footer className={styles.footer}>
-			<p>
+			<p className={styles.creditInfo}>
 				Made with <FontAwesomeIcon icon={faHeart} /> by&nbsp;
 				<a target="_blank" href="https://github.com/yashchaudhari008">
 					yashchaudhari008&nbsp;
@@ -18,17 +18,17 @@ const Footer = () => {
 				>
 					contributors
 				</a>
-				<span> |</span>
-				<span className={styles.githubContainer}>
-					<a
-						target="_blank"
-						className={styles.github}
-						href="https://github.com/yashchaudhari008/minime"
-					>
-						<FontAwesomeIcon className={styles.icon} icon={faGithub} />
-						Github Page
-					</a>
-				</span>
+				<span className={styles.seperator}> | </span>
+			</p>
+			<p className={styles.githubContainer}>
+				<a
+					target="_blank"
+					className={styles.github}
+					href="https://github.com/yashchaudhari008/minime"
+				>
+					<FontAwesomeIcon className={styles.icon} icon={faGithub} />
+					Github Page
+				</a>
 			</p>
 		</footer>
 	);

--- a/src/components/Footer/footer.module.scss
+++ b/src/components/Footer/footer.module.scss
@@ -5,8 +5,8 @@
 	width: 100%;
 	display: flex;
 	justify-content: flex-end;
-	align-items: flex-end;
-	padding-right: 24px;
+    align-items: flex-end;
+    padding-right: 24px;
 	p,
 	a {
 		font-size: 14px;
@@ -28,4 +28,11 @@
 			margin-right: 4px;
 		}
 	}
+
+	@include respond-to('small') {
+        justify-content: center;
+        align-items: center;
+		text-align: center;
+		font-size: calc(14px + 0.5vw);
+    }
 }

--- a/src/components/Footer/footer.module.scss
+++ b/src/components/Footer/footer.module.scss
@@ -34,5 +34,10 @@
         align-items: center;
 		text-align: center;
 		font-size: calc(14px + 0.5vw);
+		p {
+			span {
+			  display: none;
+			}
+		  }
     }
 }

--- a/src/components/Footer/footer.module.scss
+++ b/src/components/Footer/footer.module.scss
@@ -5,8 +5,8 @@
 	width: 100%;
 	display: flex;
 	justify-content: flex-end;
-    align-items: flex-end;
-    padding-right: 24px;
+	align-items: flex-end;
+	padding-right: 24px;
 	p,
 	a {
 		font-size: 14px;

--- a/src/components/Footer/footer.module.scss
+++ b/src/components/Footer/footer.module.scss
@@ -29,6 +29,12 @@
 		}
 	}
 
+	.githubContainer {
+        display: inline-block;
+        vertical-align: middle; 
+        margin-left: 8px; 
+    }
+
 	@include respond-to('small') {
         justify-content: center;
         align-items: center;

--- a/src/components/Footer/footer.module.scss
+++ b/src/components/Footer/footer.module.scss
@@ -5,7 +5,7 @@
 	width: 100%;
 	display: flex;
 	justify-content: flex-end;
-	align-items: flex-end;
+	align-items: center;
 	padding-right: 24px;
 	p,
 	a {
@@ -19,31 +19,33 @@
 			text-decoration: underline;
 		}
 	}
-
-	.github {
-		font-size: 20px;
-		font-weight: 800;
-		margin-left: 2px;
-		.icon {
-			margin-right: 4px;
+	.githubContainer {
+		display: inline-block;
+		vertical-align: middle;
+		margin-left: 8px;
+		.github {
+			font-size: 20px;
+			font-weight: 800;
+			margin-left: 2px;
+			.icon {
+				margin-right: 4px;
+			}
 		}
 	}
 
-	.githubContainer {
-        display: inline-block;
-        vertical-align: middle; 
-        margin-left: 8px; 
-    }
-
-	@include respond-to('small') {
-        justify-content: center;
-        align-items: center;
+	@include respond-to("small") {
+		flex-direction: column;
 		text-align: center;
+		padding-right: 0;
 		font-size: calc(14px + 0.5vw);
-		p {
-			span {
-			  display: none;
-			}
-		  }
-    }
+		.creditInfo {
+			margin-bottom: 0;
+		}
+		.githubContainer {
+			margin-top: 4px;
+		}
+		.seperator {
+			display: none;
+		}
+	}
 }

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -6,3 +6,20 @@
 @mixin font-inter {
 	font-family: "Inter", system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
+
+@mixin respond-to($breakpoint) {
+	@if $breakpoint == 'small' {
+	  @media (max-width: 600px) {
+		@content;
+	  }
+	} @else if $breakpoint == 'medium' {
+	  @media (min-width: 601px) and (max-width: 1024px) {
+		@content;
+	  }
+	} @else if $breakpoint == 'large' {
+	  @media (min-width: 1025px) {
+		@content;
+	  }
+	}
+  }
+  


### PR DESCRIPTION
Footer should now center on mobile devices (under 600px) and scale the font size according to the view window. Added a media query in footer.module.scss to change the layout of the footer on small screens and adjust the font size. Additionally, I added a Sass mixin to apply different styles based on the screen size, which currently has three size ranges; "small", "medium", and "large". This should be able to be used to scale other elements in the future. Closes issue #20.

Desktop View:
![image](https://github.com/yashchaudhari008/minime/assets/113255492/777500f4-8002-4b32-9991-91be3e6b9b17)
Mobile View:
![image](https://github.com/yashchaudhari008/minime/assets/113255492/d1e13ece-47f5-49cb-8254-f99b6112d715)
