### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,6 @@
 name: Unassign inactive contributors
+permissions:
+  issues: write
 on:
   schedule:
     - cron: '0 1 * * 1'   # Weekly at 1am UTC


### PR DESCRIPTION
Potential fix for [https://github.com/yashchaudhari008/minime/security/code-scanning/1](https://github.com/yashchaudhari008/minime/security/code-scanning/1)

To remediate this problem, explicitly set the `permissions` block in the workflow to apply the minimum necessary privileges. This should be added at the top level of the file (recommended, so all jobs inherit it unless overridden) or at the job level. For this workflow, which only unassigns contributors on issues or pull requests, the minimal privilege required is likely `issues: write` (and optionally `pull-requests: write` if PRs are also affected). Place this block immediately below the `name:` or `on:` keys for clarity and security; this ensures the `GITHUB_TOKEN` used in the workflow cannot be abused for unintended write access to repository contents or secrets. No external dependencies or imports are necessary for this change—simply modify the YAML structure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
